### PR TITLE
ci: cache install artifacts to speed up CI

### DIFF
--- a/.github/actions/base-runner/action.yml
+++ b/.github/actions/base-runner/action.yml
@@ -22,6 +22,7 @@ runs:
           llvm \
           clang-format \
           clang-tidy \
+          ccache \
           cppcheck \
           python3 \
           shellcheck \

--- a/.github/workflows/on-workflow-call-build.yml
+++ b/.github/workflows/on-workflow-call-build.yml
@@ -16,7 +16,26 @@ jobs:
       - name: base runner
         uses: ./.github/actions/base-runner
 
+      - name: cache install artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/opt/whisper.cpp
+            ~/.local/share/asryx
+            ~/.cache/ccache
+          key: ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-${{ github.job }}-
+            ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-
+            ${{ runner.os }}-install-
+
       - name: install
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          CCACHE_DIR: /home/runner/.cache/ccache
+          CCACHE_COMPRESS: "true"
+          CCACHE_MAXSIZE: 1G
         run: bash ./scripts/install
 
       - name: build

--- a/.github/workflows/on-workflow-call-lint.yml
+++ b/.github/workflows/on-workflow-call-lint.yml
@@ -16,7 +16,26 @@ jobs:
       - name: base runner
         uses: ./.github/actions/base-runner
 
+      - name: cache install artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/opt/whisper.cpp
+            ~/.local/share/asryx
+            ~/.cache/ccache
+          key: ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-${{ github.job }}-
+            ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-
+            ${{ runner.os }}-install-
+
       - name: install
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          CCACHE_DIR: /home/runner/.cache/ccache
+          CCACHE_COMPRESS: "true"
+          CCACHE_MAXSIZE: 1G
         run: bash ./scripts/install
 
       - name: lint

--- a/.github/workflows/on-workflow-call-sanitizers.yml
+++ b/.github/workflows/on-workflow-call-sanitizers.yml
@@ -16,7 +16,26 @@ jobs:
       - name: base runner
         uses: ./.github/actions/base-runner
 
+      - name: cache install artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/opt/whisper.cpp
+            ~/.local/share/asryx
+            ~/.cache/ccache
+          key: ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-${{ github.job }}-
+            ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-
+            ${{ runner.os }}-install-
+
       - name: install
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          CCACHE_DIR: /home/runner/.cache/ccache
+          CCACHE_COMPRESS: "true"
+          CCACHE_MAXSIZE: 1G
         run: bash ./scripts/install
 
       - name: runtime safety

--- a/.github/workflows/on-workflow-call-test.yml
+++ b/.github/workflows/on-workflow-call-test.yml
@@ -16,7 +16,26 @@ jobs:
       - name: base runner
         uses: ./.github/actions/base-runner
 
+      - name: cache install artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/opt/whisper.cpp
+            ~/.local/share/asryx
+            ~/.cache/ccache
+          key: ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-${{ github.job }}-
+            ${{ runner.os }}-install-${{ hashFiles('scripts/install') }}-
+            ${{ runner.os }}-install-
+
       - name: install
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          CCACHE_DIR: /home/runner/.cache/ccache
+          CCACHE_COMPRESS: "true"
+          CCACHE_MAXSIZE: 1G
         run: bash ./scripts/install
 
       - name: test

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ asryx
 
 The next invocation stops capture, transcribes locally, copies the transcript, notifies the session, and cleans the runtime directory.
 
-A compositor double-fire, key repeat, or repeated invocation during an active phase cannot create parallel recorders or corrupt the current transcription.
+The runtime is guarded by an atomic lock directory and live PID checks, so compositor double-fires, key repeat, or repeated invocations collapse into safe no ops while one active phase owns the recorder or transcription. A second process cannot start a parallel recorder, interrupt an active decode, or corrupt the transcript path.
 
 **Runtime model:**
 

--- a/README.md
+++ b/README.md
@@ -322,46 +322,33 @@ Example:
 
 ## Configuration
 
-Configuration is stored in:
+Configuration is stored in `~/.asryx.conf`.
 
-```text
-~/.asryx.conf
-```
+**Model**
 
-Default:
-
-```text
-model=base.en
-language=auto
-```
-
-`model` selects the active model. `language` controls transcription language. `auto` lets the model detect the language first before transcribing, which adds a little bit of unnecessary latency if you speak the same language all the time. Locking to a language code skips detection and transcribes instantly.
-
-English-only models (`tiny.en`, `base.en`, `small.en`, `medium.en`) accept:
-
-```text
-auto
-en
-```
-
-Multilingual models accept `auto` and every supported language code.
-
-Invalid model and language values are rejected before recording starts.
-
-Switching models through the CLI updates the config:
+`model` selects the active model. Switching via CLI updates the config instantly:
 
 ```bash
 asryx --model use small.en
 ```
 
-Switching language through the CLI updates the same config and preserves the active model:
+**Language**
+
+`language` controls transcription language. `auto` detects the language first, which adds a small amount of latency. Locking to a code skips detection entirely:
 
 ```bash
 asryx --language es
 asryx --language auto
 ```
 
-Manual edits are also valid:
+English only models (`tiny.en`, `base.en`, `small.en`, `medium.en`) only accept `en` or `auto`. Multilingual models accept any of the 99 supported language codes.
+
+> [!NOTE]
+> Language support and transcription quality are a property of the [GGML model weights](https://github.com/ggerganov/whisper.cpp/blob/d682e150908e10caa4c15883c633d7902d685237/src/whisper.cpp#L248).
+
+Invalid model and language values are rejected before recording starts.
+
+Manual edits to the config file are valid:
 
 ```text
 model=base


### PR DESCRIPTION
Since it's taking too long to wait for runners to finish.

This fixes it by adding `ccache` to the base runner toolchain and wires up install artifact caching across the 4 workflows that run the install step. 

Each workflow now persists `whisper.cpp`, the shared data dir, and the ccache dir between runs. the cache key is keyed off a hash of scripts/install so it busts automatically when the install script changes.

Plus, a few updates to the README to be more precise about the runtime lock behavior & the config section.