### PR TITLE
add VAD support

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -90,7 +90,8 @@ write_default_config_if_missing() {
 }
 
 install_vad_model() {
-  local target="$(_asryx_home_path "${ASRYX_SHARE_DIR_REL}")/${ASRYX_VAD_MODEL_FILE}"
+  local target
+  target="$(_asryx_home_path "${ASRYX_SHARE_DIR_REL}")/${ASRYX_VAD_MODEL_FILE}"
   local tmp="${target}.tmp.$$"
 
   if [[ -s "${target}" ]]; then
@@ -109,6 +110,7 @@ install_vad_model() {
   [[ -s "${tmp}" ]] || _asryx_die "downloaded VAD model is empty"
   mv -f "${tmp}" "${target}"
 }
+
 
 install_and_select_model() {
   local asryx_bin

--- a/scripts/install
+++ b/scripts/install
@@ -89,6 +89,27 @@ write_default_config_if_missing() {
   printf 'model=%s\nlanguage=%s\npipe_to=\n' "${model_name}" "${ASRYX_DEFAULT_LANGUAGE}" >"${cfg}"
 }
 
+install_vad_model() {
+  local target="$(_asryx_home_path "${ASRYX_SHARE_DIR_REL}")/${ASRYX_VAD_MODEL_FILE}"
+  local tmp="${target}.tmp.$$"
+
+  if [[ -s "${target}" ]]; then
+    _asryx_log "VAD model already installed: ${target}"
+    return 0
+  fi
+
+  _asryx_ensure_dir "$(_asryx_home_path "${ASRYX_SHARE_DIR_REL}")"
+  _asryx_log "downloading VAD model ${ASRYX_VAD_MODEL_NAME}"
+
+  if ! curl -fL --retry 3 -o "${tmp}" "${ASRYX_VAD_MODEL_URL}"; then
+    rm -f -- "${tmp}"
+    _asryx_die "failed to download VAD model"
+  fi
+
+  [[ -s "${tmp}" ]] || _asryx_die "downloaded VAD model is empty"
+  mv -f "${tmp}" "${target}"
+}
+
 install_and_select_model() {
   local asryx_bin
   asryx_bin="$(_asryx_home_path "${ASRYX_ASRYX_BIN_REL}")"
@@ -123,6 +144,7 @@ main() {
   install_asryx_binary
   write_installed_whisper_pin "${whisper_sha}"
   write_default_config_if_missing
+  install_vad_model
   install_and_select_model
   warn_path_if_needed
 }

--- a/scripts/lib/_constants.sh
+++ b/scripts/lib/_constants.sh
@@ -3,6 +3,9 @@
 # shellcheck disable=SC2034
 ASRYX_DEFAULT_MODEL="base.en"
 ASRYX_DEFAULT_LANGUAGE="auto"
+ASRYX_VAD_MODEL_NAME="silero-v6.2.0"
+ASRYX_VAD_MODEL_FILE="ggml-${ASRYX_VAD_MODEL_NAME}.bin"
+ASRYX_VAD_MODEL_URL="https://huggingface.co/ggml-org/whisper-vad/resolve/main/${ASRYX_VAD_MODEL_FILE}"
 ASRYX_CONFIG_FILE=".asryx.conf"
 ASRYX_LOCAL_BIN_DIR_REL=".local/bin"
 ASRYX_LOCAL_OPT_DIR_REL=".local/opt"

--- a/src/constants/constants.hpp
+++ b/src/constants/constants.hpp
@@ -57,6 +57,7 @@ inline constexpr std::string_view whisper_checkout_rel = ".local/opt/whisper.cpp
 inline constexpr std::string_view data_dir_rel = ".local/share/asryx";
 inline constexpr std::string_view cache_dir_rel = ".cache/asryx";
 inline constexpr std::string_view whisper_pin_rel = ".local/share/asryx/versions/whisper-cpp-sha";
+inline constexpr std::string_view VAD_MODEL_FILE = "ggml-silero-v6.2.0.bin";
 
 inline std::filesystem::path config_path(const std::filesystem::path& home)
 {

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -290,26 +290,29 @@ bool stop_recording(pid_t pid)
   return _wait_until_recorder_exits(pid);
 }
 
-std::string transcribe(const std::string& model_path, const std::string& wav_path,
-                       const std::string& language)
+std::string transcribe(const TranscriptionRequest& request)
 {
-  ASRYX_TEST_HOOK(transcribe_hook, model_path, wav_path, language);
+  ASRYX_TEST_HOOK(transcribe_hook, request);
 
-  if (!std::filesystem::exists(model_path)) {
-    throw std::runtime_error("model file does not exist: " + model_path);
+  if (!std::filesystem::exists(request.model_path)) {
+    throw std::runtime_error("model file does not exist: " + request.model_path);
   }
 
-  const auto samples = _read_pcm16_wav(wav_path);
+  if (!std::filesystem::exists(request.vad_model_path)) {
+    throw std::runtime_error("VAD model file does not exist: " + request.vad_model_path);
+  }
+
+  const auto samples = _read_pcm16_wav(request.wav_path);
 
   whisper_context_params context_params = whisper_context_default_params();
   std::unique_ptr<whisper_context, WhisperContextDeleter> ctx(
-      whisper_init_from_file_with_params(model_path.c_str(), context_params));
+      whisper_init_from_file_with_params(request.model_path.c_str(), context_params));
 
   if (ctx == nullptr) {
-    throw std::runtime_error("failed to initialize whisper model: " + model_path);
+    throw std::runtime_error("failed to initialize whisper model: " + request.model_path);
   }
 
-  const char* const language_arg = _whisper_language(ctx.get(), language);
+  const char* const language_arg = _whisper_language(ctx.get(), request.language);
 
   whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
   params.n_threads = _thread_count();
@@ -321,6 +324,9 @@ std::string transcribe(const std::string& model_path, const std::string& wav_pat
   params.suppress_nst = true;
   params.language = language_arg;
   params.detect_language = false;
+  params.vad = true;
+  params.vad_model_path = request.vad_model_path.c_str();
+  params.vad_params = whisper_vad_default_params();
 
   if (whisper_full(ctx.get(), params, samples.data(), static_cast<int>(samples.size())) != 0) {
     throw std::runtime_error("whisper transcription failed");

--- a/src/engine/engine.hpp
+++ b/src/engine/engine.hpp
@@ -6,10 +6,17 @@
 
 namespace engine {
 
+struct TranscriptionRequest
+{
+  std::string model_path;
+  std::string vad_model_path;
+  std::string wav_path;
+  std::string language;
+};
+
 pid_t start_recording(const std::string& wav_path, const std::string& err_path);
 bool stop_recording(pid_t pid);
-std::string transcribe(const std::string& model_path, const std::string& wav_path,
-                       const std::string& language);
+std::string transcribe(const TranscriptionRequest& request);
 bool copy_to_clipboard(const std::string& text);
 bool send_notification(const std::string& message);
 
@@ -17,8 +24,7 @@ bool send_notification(const std::string& message);
 namespace testing {
 using StartRecordingHook = pid_t (*)(const std::string& wav_path, const std::string& err_path);
 using StopRecordingHook = bool (*)(pid_t pid);
-using TranscribeHook = std::string (*)(const std::string& model_path, const std::string& wav_path,
-                                       const std::string& language);
+using TranscribeHook = std::string (*)(const TranscriptionRequest& request);
 using CopyToClipboardHook = bool (*)(const std::string& text);
 using NotificationHook = bool (*)(const std::string& message);
 

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -28,6 +28,11 @@ std::filesystem::path _model_dir()
   return platform::get_home_relative_path(std::string(constants::paths::data_dir_rel));
 }
 
+std::filesystem::path _vad_model_path()
+{
+  return _model_dir() / std::string(constants::paths::VAD_MODEL_FILE);
+}
+
 std::filesystem::path _whisper_source_dir()
 {
   return platform::get_home_relative_path(std::string(constants::paths::whisper_checkout_rel));
@@ -125,9 +130,19 @@ std::string get_model_path(const std::string& name)
   return (_model_dir() / ("ggml-" + name + ".bin")).string();
 }
 
+std::string get_vad_model_path()
+{
+  return _vad_model_path().string();
+}
+
 bool is_model_installed(const std::string& name)
 {
   return _file_exists_nonempty(get_model_path(name));
+}
+
+bool is_vad_model_installed()
+{
+  return _file_exists_nonempty(_vad_model_path());
 }
 
 bool is_supported_language(const std::string& language)
@@ -164,6 +179,14 @@ void validate_config(const config::Config& cfg)
   }
 }
 
+void validate_vad_model()
+{
+  const auto path = _vad_model_path();
+  if (!_file_exists_nonempty(path)) {
+    throw std::runtime_error("VAD model is not installed: " + path.string());
+  }
+}
+
 std::string transcription_language_for(const config::Config& cfg)
 {
   validate_config(cfg);
@@ -191,6 +214,10 @@ void list_models()
     std::cout << "  " << (active ? "* " : "  ") << model_name << (installed ? " (installed)" : "")
               << (active ? " (active)" : "") << "\n";
   }
+
+  std::cout << "\nVAD model:\n";
+  std::cout << "  " << constants::paths::VAD_MODEL_FILE
+            << (is_vad_model_installed() ? " (installed)" : " (missing)") << "\n";
 }
 
 void install_model(const std::string& name)

--- a/src/model/model.hpp
+++ b/src/model/model.hpp
@@ -13,10 +13,13 @@ namespace model {
 const std::vector<std::string>& get_supported_models();
 const std::vector<std::string>& get_supported_languages();
 std::string get_model_path(const std::string& name);
+std::string get_vad_model_path();
 bool is_model_installed(const std::string& name);
+bool is_vad_model_installed();
 bool is_supported_language(const std::string& language);
 bool is_english_only_model(const std::string& name);
 void validate_config(const config::Config& cfg);
+void validate_vad_model();
 std::string transcription_language_for(const config::Config& cfg);
 void list_models();
 void install_model(const std::string& name);

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -191,6 +191,8 @@ void _start_recording(const std::filesystem::path& runtime_dir)
                              config.model);
   }
 
+  model::validate_vad_model();
+
   const auto wav_path = runtime_dir / std::string(constants::runtime::recorder_wav_file);
   const auto err_path = runtime_dir / std::string(constants::runtime::recorder_error_file);
   const pid_t pid = engine::start_recording(wav_path.string(), err_path.string());
@@ -247,9 +249,11 @@ void _stop_and_transcribe(const std::filesystem::path& runtime_dir, pid_t rec_pi
 
   const auto config = config::load_config();
   const auto language = model::transcription_language_for(config);
-  const auto model_path = model::get_model_path(config.model);
   const auto wav_path = runtime_dir / std::string(constants::runtime::recorder_wav_file);
-  const auto output = _trim(engine::transcribe(model_path, wav_path.string(), language));
+  const engine::TranscriptionRequest request{model::get_model_path(config.model),
+                                             model::get_vad_model_path(), wav_path.string(),
+                                             language};
+  const auto output = _trim(engine::transcribe(request));
 
   if (output.empty()) {
     engine::send_notification("no output");

--- a/tests/test_app.cpp
+++ b/tests/test_app.cpp
@@ -45,11 +45,14 @@ void write_fake_model()
       std::filesystem::path(model::get_model_path(default_model)).parent_path());
   std::ofstream model_file(model::get_model_path(default_model));
   model_file << "fake model content";
+  std::ofstream vad_file(model::get_vad_model_path());
+  vad_file << "fake VAD model content";
 }
 
 void delete_fake_model()
 {
   platform::safe_delete_file(model::get_model_path(std::string(constants::config::default_model)));
+  platform::safe_delete_file(model::get_vad_model_path());
 }
 
 void reset_config()

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -49,6 +49,10 @@ void run_test_model()
 
   std::string path = model::get_model_path(std::string(constants::config::default_model));
   ASSERT_TRUE(!path.empty());
+  ASSERT_TRUE(!model::get_vad_model_path().empty());
+  ASSERT_FALSE(model::is_vad_model_installed());
+  ASSERT_TRUE(runtime_error_equals([] { model::validate_vad_model(); },
+                                   "VAD model is not installed: " + model::get_vad_model_path()));
 
   ASSERT_FALSE(model::is_model_installed(std::string(constants::config::default_model)));
   ASSERT_TRUE(runtime_error_equals(

--- a/tests/test_runtime.cpp
+++ b/tests/test_runtime.cpp
@@ -125,12 +125,9 @@ bool fake_stop(pid_t pid)
   return pid == getpid();
 }
 
-std::string fake_transcribe(const std::string& model_path, const std::string& wav_path,
-                            const std::string& language)
+std::string fake_transcribe(const engine::TranscriptionRequest& request)
 {
-  (void)model_path;
-  (void)wav_path;
-  (void)language;
+  (void)request;
   auto& s = state();
   ++s.transcribe_calls;
   std::ifstream state_file(runtime_file(std::string(constants::runtime::state_file)));
@@ -172,6 +169,8 @@ void write_fake_model()
       std::filesystem::path(model::get_model_path(default_model)).parent_path());
   std::ofstream model_file(model::get_model_path(default_model));
   model_file << "fake model content";
+  std::ofstream vad_file(model::get_vad_model_path());
+  vad_file << "fake VAD model content";
 }
 
 void reset_config(const std::string& pipe_to = "")


### PR DESCRIPTION
This adds speech gate before Whisper wastes work.

Previously, the entire recording was passed directly to Whisper regardless of its contents: long pauses, silence, background noise & any other non speech regions were processed alongside spoken audio.

Which means unnecessary compute & hallucinated text.
 
This feature is enabled by default. 

During installation, the required VAD model is downloaded and installed alongside the default Whisper model, and the runtime validates that both models are available before transcription begins.