### PR TITLE
add installer compiler fallback

### DIFF
--- a/.github/actions/base-runner/action.yml
+++ b/.github/actions/base-runner/action.yml
@@ -12,30 +12,17 @@ runs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           ca-certificates \
-          gnupg \
-          curl
-
-        llvm_keyring="/usr/share/keyrings/llvm-snapshot.gpg"
-        curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key |
-          sudo gpg --dearmor -o "${llvm_keyring}"
-        printf '%s\n' \
-          "deb [signed-by=${llvm_keyring}] https://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" |
-          sudo tee /etc/apt/sources.list.d/llvm-toolchain-noble-21.list >/dev/null
-
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends \
-          ca-certificates \
           bash \
           git \
           curl \
           cmake \
           ninja-build \
-          g++-14 \
-          gcc-14 \
-          clang-21 \
-          llvm-21 \
-          clang-format-21 \
-          clang-tidy-21 \
+          g++ \
+          gcc \
+          clang \
+          libclang-rt-dev \
+          clang-format \
+          clang-tidy \
           ccache \
           cppcheck \
           python3 \
@@ -47,12 +34,4 @@ runs:
           wl-clipboard \
           xclip \
           libnotify-bin
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 140
-        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 140
-        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 140
-        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-21 210
-        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 210
-        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-21 210
-        sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-21 210
         sudo rm -rf /var/lib/apt/lists/*

--- a/.github/actions/base-runner/action.yml
+++ b/.github/actions/base-runner/action.yml
@@ -9,29 +9,66 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+
         sudo apt-get update
+
+        # apt.llvm repo setup needs tls, gpg, and curl.
         sudo apt-get install -y --no-install-recommends \
           ca-certificates \
-          bash \
-          git \
-          curl \
-          cmake \
-          ninja-build \
-          g++ \
-          gcc \
-          clang \
-          libclang-rt-dev \
-          clang-format \
-          clang-tidy \
-          ccache \
-          cppcheck \
-          python3 \
-          shellcheck \
-          just \
-          coreutils \
-          pipewire \
-          alsa-utils \
-          wl-clipboard \
-          xclip \
+          gnupg \
+          curl
+
+        # ubuntu 24.04 doesn't ship llvm 21 in its normal repos.
+        llvm_keyring="/usr/share/keyrings/llvm-snapshot.gpg"
+        curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key |
+          sudo gpg --dearmor -o "${llvm_keyring}"
+        printf '%s\n' \
+          "deb [signed-by=${llvm_keyring}] https://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" |
+          sudo tee /etc/apt/sources.list.d/llvm-toolchain-noble-21.list >/dev/null
+
+        sudo apt-get update
+
+        # system tools used by checkout, cmake, scripts, and ci checks.
+        system_packages=(
+          ca-certificates
+          bash
+          git
+          curl
+          cmake
+          ninja-build
+          g++-14
+          gcc-14
+          ccache
+          cppcheck
+          python3
+          shellcheck
+          just
+          coreutils
+        )
+
+        # clang 21 matches the local formatter/linter/compiler line.
+        # libclang-rt has sanitizer runtimes such as libclang_rt.asan.a.
+        clang_packages=(
+          clang-21
+          libclang-rt-21-dev
+          clang-format-21
+          clang-tidy-21
+        )
+
+        # runtime packages let install smoke test paths exercise desktop integrations.
+        runtime_packages=(
+          pipewire
+          alsa-utils
+          wl-clipboard
+          xclip
           libnotify-bin
+        )
+
+        sudo apt-get install -y --no-install-recommends \
+          "${system_packages[@]}" \
+          "${clang_packages[@]}" \
+          "${runtime_packages[@]}"
+
+        # prefer llvm 21 tools without mutating system alternatives.
+        printf '%s\n' "/usr/lib/llvm-21/bin" >>"${GITHUB_PATH}"
         sudo rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,6 @@ jobs:
 
   install-uninstall:
     needs:
-      - test
-      - sanitizers
+      - shellcheck
+      - format
     uses: ./.github/workflows/on-workflow-call-distros.yml

--- a/.github/workflows/on-workflow-call-build.yml
+++ b/.github/workflows/on-workflow-call-build.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/on-workflow-call-check-changes.yml
+++ b/.github/workflows/on-workflow-call-check-changes.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   detect:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       non_docs: ${{ steps.detect.outputs.non_docs }}
     steps:

--- a/.github/workflows/on-workflow-call-distros.yml
+++ b/.github/workflows/on-workflow-call-distros.yml
@@ -27,7 +27,7 @@ jobs:
             image: archlinux:latest
             toolchain: distro-default
 
-    name: install / ${{ matrix.distro }} / ${{ matrix.toolchain }}
+    name: smoke / ${{ matrix.distro }} / ${{ matrix.toolchain }}
     container:
       image: ${{ matrix.image }}
 

--- a/.github/workflows/on-workflow-call-distros.yml
+++ b/.github/workflows/on-workflow-call-distros.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   smoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/on-workflow-call-distros.yml
+++ b/.github/workflows/on-workflow-call-distros.yml
@@ -11,14 +11,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - id: debian-trixie-c++23
+          - distro: debian-trixie
             image: debian:trixie
-          - id: fedora-latest-c++23
+            toolchain: clang-19
+          - distro: debian-trixie
+            image: debian:trixie
+            toolchain: gcc-14
+          - distro: ubuntu-24.04
+            image: ubuntu:24.04
+            toolchain: distro-default
+          - distro: fedora-latest
             image: fedora:latest
-          - id: arch-latest-c++23
+            toolchain: distro-default
+          - distro: arch-latest
             image: archlinux:latest
+            toolchain: distro-default
 
-    name: ${{ matrix.id }}
+    name: install / ${{ matrix.distro }} / ${{ matrix.toolchain }}
     container:
       image: ${{ matrix.image }}
 
@@ -34,6 +43,10 @@ jobs:
           if command -v apt-get >/dev/null 2>&1; then
             export DEBIAN_FRONTEND=noninteractive
             apt-get update
+            compiler_packages=(g++)
+            if [[ "${{ matrix.toolchain }}" == "clang-19" ]]; then
+              compiler_packages=(clang)
+            fi
             apt-get install -y --no-install-recommends \
               sudo \
               ca-certificates \
@@ -42,7 +55,7 @@ jobs:
               curl \
               cmake \
               ninja-build \
-              g++ \
+              "${compiler_packages[@]}" \
               coreutils \
               pipewire \
               alsa-utils \
@@ -87,6 +100,26 @@ jobs:
             echo "no supported package manager found" >&2
             exit 1
           fi
+
+      - name: toolchain summary
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if command -v clang >/dev/null 2>&1 && command -v clang++ >/dev/null 2>&1; then
+            cc=clang
+            cxx=clang++
+          elif command -v gcc >/dev/null 2>&1 && command -v g++ >/dev/null 2>&1; then
+            cc=gcc
+            cxx=g++
+          else
+            echo "missing compiler pair" >&2
+            exit 1
+          fi
+
+          cmake --version | sed -n '1p'
+          "${cc}" --version | sed -n '1p'
+          "${cxx}" --version | sed -n '1p'
 
       - name: ci user
         shell: bash

--- a/.github/workflows/on-workflow-call-format.yml
+++ b/.github/workflows/on-workflow-call-format.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/on-workflow-call-sanitizers.yml
+++ b/.github/workflows/on-workflow-call-sanitizers.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   sanitizers:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v7

--- a/.github/workflows/on-workflow-call-shell-check.yml
+++ b/.github/workflows/on-workflow-call-shell-check.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/on-workflow-call-test.yml
+++ b/.github/workflows/on-workflow-call-test.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ target_link_options(asryx PRIVATE -Wl,--gc-sections)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   add_custom_command(TARGET asryx POST_BUILD
-    COMMAND strip -s $<TARGET_FILE:asryx>
+    COMMAND "${CMAKE_STRIP}" -s $<TARGET_FILE:asryx>
   )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -282,13 +282,13 @@ transcribing
 
 If you hear sound, see notifications, and have installed a non TTY distro, you probably have everything you need already, but check in case you spawned in a bare metal setup:
 
-* **Build Tools:** `git`, `curl`, `cmake`, `ninja-build`, `g++` (or `clang++`)
+* **Build Tools:** `git`, `curl`, `cmake`, `ninja-build`, `clang++` or `g++`
 * **Audio Recording:** `pipewire` (for `pw-record`) **or** `alsa-utils` (for `arecord`)
 * **Clipboard:** `wl-clipboard` (Wayland) **or** `xclip` (X11)
 * **Desktop Notifications:** `libnotify-bin` (for `notify-send`)
 
 > [!IMPORTANT]
-> The build requires a **C++23** capable compiler (e.g., GCC ≥ 12/14 or Clang ≥ 16/21) and CMake ≥ 3.20.
+> The build requires a **C++23** capable compiler and CMake >= 3.25. The installer prefers Clang and falls back to GCC. On old distros, install Clang 19+ or GCC 14+ before running `./package/install`.
 
 The default is CPU build. GPU builds need extra system packages, see [GPU builds](./docs/gpu.md).
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ If you hear sound, see notifications, and have installed a non TTY distro, you p
 * **Desktop Notifications:** `libnotify-bin` (for `notify-send`)
 
 > [!IMPORTANT]
-> The build requires a **C++23** capable compiler and CMake >= 3.25. The installer prefers Clang and falls back to GCC. On old distros, install Clang 19+ or GCC 14+ before running `./package/install`.
+> The build requires a **C++23** capable compiler and CMake >= 3.25. On old distros, install Clang 19+ or GCC 14+ before running `./package/install`.
 
 The default is CPU build. GPU builds need extra system packages, see [GPU builds](./docs/gpu.md).
 

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ tidy_jobs := "2"
 	{{cpp_sources}} | xargs -0 -r clang-format --dry-run --Werror
 
 @test:
-	cmake --fresh --preset test
+	CC=clang CXX=clang++ cmake --fresh --preset test
 	cmake --build --preset test --target asryx_tests
 	ctest --preset test
 
@@ -44,8 +44,8 @@ tidy_jobs := "2"
 	python3 lint/check-line-limits.py
 	python3 lint/check-module-boundaries.py
 	python3 lint/check-owned-paths.py
-	cmake --fresh --preset release
-	cmake --fresh --preset test
+	CC=clang CXX=clang++ cmake --fresh --preset release
+	CC=clang CXX=clang++ cmake --fresh --preset test
 	{{src_tidy_sources}} | xargs -0 -r -n 1 -P "{{tidy_jobs}}" clang-tidy --config-file=.clang-tidy -p build/release
 	{{test_tidy_sources}} | xargs -0 -r -n 1 -P "{{tidy_jobs}}" clang-tidy --config-file=.clang-tidy -p build/test
 	cppcheck --enable=all --error-exitcode=1 --inline-suppr --suppress=checkersReport --suppress=missingInclude --suppress=normalCheckLevelMaxBranches --suppressions-list=cppcheck.suppressions --std=c++23 -I src -I tests -I . src tests
@@ -54,23 +54,23 @@ tidy_jobs := "2"
 	shellcheck -x package/install package/uninstall package/lib/_common.sh package/lib/_deps.sh package/lib/deps/whisper-cpp.sh package/lib/deps/libassert.sh
 
 @build:
-	cmake --fresh --preset release
+	CC=clang CXX=clang++ cmake --fresh --preset release
 	cmake --build --preset release
 
 @build-cuda:
-	cmake --fresh --preset release-cuda
+	CC=clang CXX=clang++ cmake --fresh --preset release-cuda
 	cmake --build --preset release-cuda
 
 @build-vulkan:
-	cmake --fresh --preset release-vulkan
+	CC=clang CXX=clang++ cmake --fresh --preset release-vulkan
 	cmake --build --preset release-vulkan
 
 
 @sanitizers:
-	cmake --fresh --preset asan
+	CC=clang CXX=clang++ cmake --fresh --preset asan
 	cmake --build --preset asan --target asryx_tests
 	ctest --preset asan
-	cmake --fresh --preset ubsan
+	CC=clang CXX=clang++ cmake --fresh --preset ubsan
 	cmake --build --preset ubsan --target asryx_tests
 	ctest --preset ubsan
 

--- a/package/install
+++ b/package/install
@@ -17,6 +17,8 @@ export GIT_TERMINAL_PROMPT=0
 model_name="${ASRYX_DEFAULT_MODEL}"
 backend="cpu"
 install_dev=0
+compiler_cc=""
+compiler_cxx=""
 
 select_backend() {
   local requested="$1"
@@ -77,11 +79,32 @@ install_package_deps() {
   done
 }
 
+select_compiler() {
+  if _asryx_have clang && _asryx_have clang++; then
+    compiler_cc="clang"
+    compiler_cxx="clang++"
+    return 0
+  fi
+
+  if _asryx_have gcc && _asryx_have g++; then
+    compiler_cc="gcc"
+    compiler_cxx="g++"
+    return 0
+  fi
+
+  _asryx_die "missing C++23 compiler: install clang++ or g++"
+}
+
 build_asryx() {
   local preset="$1"
 
   _asryx_log "configuring asryx (${backend})"
-  cmake --fresh --preset "${preset}" -S "${repo_dir}"
+  cmake \
+    --fresh \
+    --preset "${preset}" \
+    -S "${repo_dir}" \
+    -DCMAKE_C_COMPILER="${compiler_cc}" \
+    -DCMAKE_CXX_COMPILER="${compiler_cxx}"
 
   _asryx_log "building asryx (${backend})"
   cmake --build "${repo_dir}/build/${preset}" --target asryx
@@ -158,6 +181,11 @@ main() {
 
   _asryx_require_runtime_dependencies
   _asryx_require_backend_dependencies "${backend}"
+
+  select_compiler
+  export CC="${compiler_cc}"
+  export CXX="${compiler_cxx}"
+  _asryx_log "compiler: $(${compiler_cxx} --version | sed -n '1p')"
 
   install_package_deps
 

--- a/package/lib/_deps.sh
+++ b/package/lib/_deps.sh
@@ -96,8 +96,8 @@ _asryx_require_runtime_dependency_tools() {
   _asryx_require_command curl
   _asryx_require_command sha256sum
 
-  _asryx_require_one_command "c compiler" cc gcc clang
-  _asryx_require_one_command "c++ compiler" c++ g++ clang++
+  _asryx_require_one_command "c compiler" clang gcc cc
+  _asryx_require_one_command "c++ compiler" clang++ g++ c++
 
   _asryx_require_audio_backend
   _asryx_require_clipboard_backend


### PR DESCRIPTION
It' easier to install now. The installer automatically picks the best compiler available on the machine (prefers clang and falls back to gcc, auto) + the supported distro install path is now  CI tested more clearly across major ones
